### PR TITLE
[IMAGE] Containerize Mintlify docs with Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,50 @@
+# Git files
+.git
+.gitignore
+
+# Docker files
+Dockerfile
+.dockerignore
+
+# Documentation build artifacts
+.mintlify
+node_modules
+
+# System files
+.DS_Store
+Thumbs.db
+
+# Logs
+*.log
+npm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage
+
+# Dependency directories
+node_modules/
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Use Node.js official image
+FROM node:18-alpine
+
+# Set working directory
+WORKDIR /app
+
+# Install Mintlify CLI globally
+RUN npm install -g mintlify
+
+# Copy all documentation files
+COPY . .
+
+# Expose port 3000 (default Mintlify dev port)
+EXPOSE 3000
+
+# Command to run Mintlify dev server
+CMD ["mintlify", "dev"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,18 @@ WORKDIR /app
 # Install Mintlify CLI globally
 RUN npm install -g mintlify
 
+# Create a user and group with specific UID and GID so kubernetes knows
+# it's not a root user
+RUN addgroup -g 1001 centml && adduser -D -s /bin/bash -u 1001 -G centml centml
+
 # Copy all documentation files
 COPY . .
+
+# Change ownership of the app directory to centml user
+RUN chown -R centml:centml /app
+
+# Switch to non-root user
+USER 1001:1001
 
 # Expose port 3000 (default Mintlify dev port)
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+services:
+  docs:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## 🐳 Containerize Mintlify docs with Docker

Added Docker support to run the CentML Platform documentation locally in a container:

- **Dockerfile**: Sets up Node.js environment with Mintlify CLI
- **docker-compose.yml**: Enables easy local development with live reload
- **.dockerignore**: Optimizes build performance

**Usage:**
```bash
docker-compose up --build
```

Or build and run the container directly:
```bash
# Build the image
docker build -t centml-docs .

# Run the container
docker run -p 3000:3000 centml-docs
```
Docs will be available at `http://localhost:3000`

## build result

```log
REPOSITORY                         TAG                  IMAGE ID       CREATED         SIZE
centml_platform_docs-docs          latest               d4886ab25f7c   6 minutes ago   893MB
```

## Screenshots

<img width="346" height="120" alt="image" src="https://github.com/user-attachments/assets/d971d01e-c4ed-4824-9432-328895067e2d" />
<img width="1007" height="1178" alt="image" src="https://github.com/user-attachments/assets/25bf2982-942c-4fd4-9abb-86573178c790" />
