### PR TITLE
fix: pin mintlify CLI to v4.2.28

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Install Mintlify CLI globally
-RUN npm install -g mintlify
+RUN npm install -g mintlify@4.2.28
 
 # Create a user and group with specific UID and GID so kubernetes knows
 # it's not a root user


### PR DESCRIPTION
## Summary
- Pin `mintlify` to v4.2.28 (the version current when the Dockerfile was first added in #26) to prevent newer versions from introducing breaking changes to the Docker build

## Test plan
- [x] `docker-compose up --build -d` starts successfully
- [x] `http://localhost:3000` serves docs