### PR TITLE
docs: update Privacy Policy and ToS footer links to CentML

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -96,7 +96,7 @@
         "items": [
           {
             "label": "Privacy Policy",
-            "href": "https://www.nvidia.com/en-us/about-nvidia/privacy-policy/"
+            "href": "https://app.centml.com/privacy-policy/"
           },
           {
             "label": "Your Privacy Choices",
@@ -109,7 +109,7 @@
         "items": [
           {
             "label": "Terms of Service",
-            "href": "https://www.nvidia.com/en-us/about-nvidia/terms-of-service/"
+            "href": "https://app.centml.com/terms-of-service/"
           },
           {
             "label": "Accessibility",


### PR DESCRIPTION
## Summary
- Point footer **Privacy Policy** link from `nvidia.com/.../privacy-policy/` → `https://app.centml.com/privacy-policy/`
- Point footer **Terms of Service** link from `nvidia.com/.../terms-of-service/` → `https://app.centml.com/terms-of-service/`
- "Your Privacy Choices" intentionally left pointing to NVIDIA Privacy Center — CentML does not yet have an equivalent page

## Scope
Only `docs.json` is modified. Mintlify renders `footer.links` directly from this config, so the change is config-only with no content/code impact.

## Test plan
| Check | Command | Result |
| --- | --- | --- |
| Valid JSON | `jq . docs.json > /dev/null` | passes |
| Only intended hrefs changed | `git diff main -- docs.json` | 2 lines changed; both are href values inside `footer.links` |
| Other footer links untouched | inspect diff | Privacy Choices / Accessibility / Corporate Policies unchanged |
| Live footer renders new URLs | manual after Mintlify preview deploy | to verify in PR preview |

Signed-off-by: Honglin Cao <hocao@nvidia.com>