### PR TITLE
docs: require protection on all deployment endpoints

### DIFF
--- a/docs/apps/compute.mdx
+++ b/docs/apps/compute.mdx
@@ -53,17 +53,17 @@ The instance comes preloaded with the libraries included in your selected base i
     Learn how to interact with the NVIDIA CCluster programmatically
   </Card>
   <Card
-    title="Private Inference Endpoints"
+    title="Securing Endpoints"
     icon="lock"
     href="/resources/private"
   >
-Learn how to create private inference endpoints
+Learn how to protect your endpoints with Bearer tokens and mTLS certificates
  </Card>
   <Card
     title="LLM Serving"
     icon="messages"
     href="/apps/llm"
   >
-    Explore dedicated public and private endpoints for production model deployments.
+    Explore dedicated, protected endpoints for production model deployments.
  </Card>
 </CardGroup>

--- a/docs/apps/inference.mdx
+++ b/docs/apps/inference.mdx
@@ -30,7 +30,7 @@ Under the **Optional Details** tab:
 </Frame>
 
 <Tip>
-To make the endpoint private, select the "Make it a private endpoint?" option. This will automatically generate a TLS certificate, which you can download as a .pem file after the deployment is complete. Only those with this TLS certificate will have access to the endpoint. For more details, please refer to this [resource](/resources/private).
+Every deployment must be protected — there are no public endpoints. Secure your endpoint with a Bearer token (an `Authorization: Bearer <token>` header), an mTLS client certificate, or both. To enable mTLS, select the "Make it a private endpoint?" option, which generates a TLS certificate you can download as a .pem file after the deployment is complete. For more details, see [Securing Endpoints](/resources/private).
 </Tip>
 
 <Tip>
@@ -102,6 +102,8 @@ Once the deployment status is ready, the container port is going to be exposed u
 
 All deployments are exposed externally on **port 443** with **TLS enforced**. CCluster automatically provisions TLS certificates for your endpoint - no additional configuration is required.
 
+Endpoints are never public: every request must authenticate with a Bearer token or a client certificate. See [Securing Endpoints](/resources/private) for details.
+
 | Protocol | Access URL | Description |
 |----------|-----------|-------------|
 | HTTP | `https://<endpoint_url>` | Standard HTTPS access (port 443 is implicit) |
@@ -126,11 +128,11 @@ For gRPC deployments, see [gRPC Inference Endpoints](/resources/grpc) for connec
 
 <CardGroup cols={3}>
   <Card
-    title="Private Inference Endpoints"
+    title="Securing Endpoints"
     icon="lock"
     href="/resources/private"
   >
-Learn how to create private inference endpoints
+Learn how to protect your endpoints with Bearer tokens and mTLS certificates
  </Card>
   <Card
     title="Clients"
@@ -144,6 +146,6 @@ Learn how to create private inference endpoints
     icon="messages"
     href="/apps/llm"
   >
-    Explore dedicated public and private endpoints for production model deployments.
+    Explore dedicated, protected endpoints for production model deployments.
  </Card>
 </CardGroup>

--- a/docs/apps/llm.mdx
+++ b/docs/apps/llm.mdx
@@ -42,8 +42,11 @@ For advanced users, NVIDIA CCluster also offers an option to customize their mod
 ## 3. Deploy and integrate
 Finally, click "Deploy". Once the deployment is ready in a few minutes, copy the endpoint url and go to `https://<endpoint_url>/docs` to find the list of API endpoints to start using your LLM deployment. We offer API compatibility with CServe, OpenAI, and Cortex, making integration with other applications seamless.
 
+Endpoints are never public, so every request must authenticate with a Bearer token or a client certificate. The example below uses a Bearer token; see [Securing Endpoints](/resources/private) for all options.
+
 ```bash
 curl -X 'POST' 'https://<endpoint_url>/openai/v1/chat/completions' \
+  -H 'Authorization: Bearer <your_bearer_token>' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
   -d '{
@@ -81,11 +84,11 @@ For more details on how to use the LLM deployment, please refer to the [examples
     Learn how to interact with the NVIDIA CCluster programmatically
   </Card>
   <Card
-    title="Private Inference Endpoints"
+    title="Securing Endpoints"
     icon="lock"
     href="/resources/private"
   >
-Learn how to create private inference endpoints
+Learn how to protect your endpoints with Bearer tokens and mTLS certificates
  </Card>
   <Card
     title="Agents on NVIDIA CCluster"

--- a/docs/home/quickstart.mdx
+++ b/docs/home/quickstart.mdx
@@ -24,12 +24,12 @@ Once logged in, you will see the NVIDIA CCluster console home page, as shown bel
 
 
 ## 2. Create a bearer token
-To interact with NVIDIA CCluster endpoints programmatically, you need a Bearer Token. Follow the [Managing Vault Objects](/resources/vault) documentation to generate one.
+Endpoints are never public — every request must authenticate with a Bearer token or a client certificate. To interact with NVIDIA CCluster endpoints programmatically, generate a Bearer Token by following the [Managing Vault Objects](/resources/vault) documentation. For all protection options, see [Securing Endpoints](/resources/private).
 
 ## 3. Deploy your first model
 Choose the deployment type that fits your use case:
 
-- **[LLM Serving](/apps/llm)** — Deploy dedicated public or private LLM endpoints tailored to your performance requirements and budget.
+- **[LLM Serving](/apps/llm)** — Deploy dedicated, protected LLM endpoints tailored to your performance requirements and budget.
 - **[General Inference](/apps/inference)** — Deploy custom containerized models on NVIDIA-managed infrastructure.
 - **[Compute](/apps/compute)** — Provision GPU compute for training, fine-tuning, or batch workloads.
 
@@ -47,7 +47,7 @@ For access, billing, sales, or technical assistance, follow our [Requesting Supp
     icon="messages"
     href="/apps/llm"
   >
-    Explore dedicated public and private endpoints for production model deployments.
+    Explore dedicated, protected endpoints for production model deployments.
  </Card>
   <Card
     title="Deploying Custom Models"

--- a/docs/resources/custom_image.mdx
+++ b/docs/resources/custom_image.mdx
@@ -34,7 +34,7 @@ For **private images**, you will need to provide registry credentials so CCluste
     icon="messages"
     href="/apps/llm"
   >
-    Explore dedicated public and private endpoints for production model and model infrastructure management.
+    Explore dedicated, protected endpoints for production model and model infrastructure management.
  </Card>
   <Card
     title="Clients"

--- a/docs/resources/grpc.mdx
+++ b/docs/resources/grpc.mdx
@@ -64,7 +64,7 @@ The file is mounted at `<mount path>/<filename>`, so set **Add command** to run 
 </Frame>
 
 <Tip>
-To restrict access, select **Make it a private endpoint?**. CCluster then generates a TLS certificate that clients must present. See [Private Inference Endpoints](/resources/private) for details.
+Every endpoint is protected — there are no public endpoints. Secure access with a Bearer token, an mTLS client certificate, or both. For mTLS, select **Make it a private endpoint?** and CCluster generates a TLS certificate that clients must present. See [Securing Endpoints](/resources/private) for details.
 </Tip>
 
 ## 2. Select the cluster and hardware
@@ -112,7 +112,7 @@ grpcurl -d '{"request_id": "1", "text": "The capital of France is", "sampling_pa
 ```
 
 <Note>
-For a private endpoint, pass the downloaded certificate to your client (for `grpcurl`, use `-cert` / `-key`). See [Private Inference Endpoints](/resources/private).
+Endpoints are protected, so authenticate every call — pass a Bearer token, or for an mTLS endpoint pass the downloaded certificate to your client (for `grpcurl`, use `-cert` / `-key`). See [Securing Endpoints](/resources/private).
 </Note>
 
 ## What's next

--- a/docs/resources/model_integration_lifecycle.mdx
+++ b/docs/resources/model_integration_lifecycle.mdx
@@ -50,7 +50,7 @@ For more implementation guidance, review the [Codex examples](/examples/codex) a
     icon="messages"
     href="/apps/llm"
   >
-    Explore dedicated public and private endpoints for production model deployments.
+    Explore dedicated, protected endpoints for production model deployments.
   </Card>
   <Card
     title="Deploying Custom Models"

--- a/docs/resources/private.mdx
+++ b/docs/resources/private.mdx
@@ -1,12 +1,51 @@
 ---
-title: 'Private Inference Endpoints'
-description: 'How to create private inference endpoints'
+title: 'Securing Endpoints'
+description: 'How to protect your inference endpoints with Bearer tokens and mTLS certificates'
 icon: 'lock'
 ---
 
-By default, endpoints created for both LLM Serving and General Inference deployments are publicly accessible. If you prefer restricted access, you can make the endpoint private by selecting the <em>Make it a private endpoint?</em> option.
+NVIDIA CCluster does not expose public endpoints. Every LLM Serving and General Inference deployment must be protected, and clients must authenticate on each request. You secure a deployment with **at least one** of the following:
 
-This setting generates a TLS certificate upon deployment, which you can download. Access to the endpoint will then require the http client to use this certificate. Here are a few examples:
+- **Bearer token** — an `Authorization: Bearer <token>` header on each request.
+- **mTLS client certificate** — a TLS certificate the client presents on each request.
+
+You choose the protection method when configuring a deployment. You may enable both for defense in depth.
+
+## Bearer token access
+
+Generate a Bearer token from your [Vault](/resources/vault), then include it in the `Authorization` header of every request.
+
+**Using curl command**
+```bash
+curl -X 'POST' 'https://<endpoint_url>/openai/v1/chat/completions' \
+  -H 'Authorization: Bearer <your_bearer_token>' \
+  -H 'accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "messages": [
+    {
+      "role": "user",
+      "content": "what is the meaning of life?"
+    }
+  ],
+  "model": "meta-llama/Llama-3.2-3B-Instruct",
+  "max_tokens": 512
+}'
+```
+
+**Using OpenAI client library**
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="<your_bearer_token>",
+    base_url="https://<endpoint url>/openai/v1",
+)
+```
+
+## mTLS certificate access
+
+Select the <em>Make it a private endpoint?</em> option when configuring a deployment. This generates a TLS certificate upon deployment, which you can download. Access to the endpoint will then require the http client to use this certificate. Here are a few examples:
 
 
 **Using curl command**

--- a/docs/resources/requesting_support.mdx
+++ b/docs/resources/requesting_support.mdx
@@ -154,7 +154,7 @@ Congratulations! You now know how to submit your first support request!
     icon="messages"
     href="/apps/llm"
   >
-    Explore dedicated public and private endpoints for production model deployments.
+    Explore dedicated, protected endpoints for production model deployments.
  </Card>
   <Card
     title="Clients"
@@ -164,10 +164,10 @@ Congratulations! You now know how to submit your first support request!
     Learn how to interact with the NVIDIA CCluster programmatically
   </Card>
   <Card
-    title="Private Endpoints"
+    title="Securing Endpoints"
     icon="lock"
     href="/resources/private"
   >
-    Learn about how you can configure private endpoints on the NVIDIA CCluster.
+    Learn how to protect your endpoints with Bearer tokens and mTLS certificates.
  </Card>
 </CardGroup>

--- a/docs/resources/vault.mdx
+++ b/docs/resources/vault.mdx
@@ -61,7 +61,7 @@ You can generate or add public certificates for mTLS just like you can with Bear
     <img src="/images/added-certificate.png" alt="Generated certificate listed in the vault" style={{ borderRadius: '0.5rem' }} />
 </Frame>
 
-When generated, `Vault Certificates` download a `.pem` file to your local browser. That `.pem` file is named after the generated cert. You can then use that `.pem` file to access one of NVIDIA CCluster's [private endpoints](/resources/private) as long as they are associated with the appropriate certificate and `.pem` pair.
+When generated, `Vault Certificates` download a `.pem` file to your local browser. That `.pem` file is named after the generated cert. You can then use that `.pem` file to access one of NVIDIA CCluster's [secured endpoints](/resources/private) as long as they are associated with the appropriate certificate and `.pem` pair.
 
 
 <Frame>
@@ -133,14 +133,14 @@ Supported registries include Docker Hub, Amazon ECR, Google Artifact Registry, A
     icon="messages"
     href="/apps/llm"
   >
-    Explore dedicated public and private endpoints for production model deployments.
+    Explore dedicated, protected endpoints for production model deployments.
  </Card>
   <Card
-    title="Private Inference Endpoints"
+    title="Securing Endpoints"
     icon="lock"
     href="/resources/private"
   >
-Learn how to create private inference endpoints
+Learn how to protect your endpoints with Bearer tokens and mTLS certificates
  </Card>
   <Card
     title="Clients"


### PR DESCRIPTION
Closes CCL-131

Public endpoints are gone, so the docs now state every deployment must be secured with a Bearer token and/or mTLS certificate. Refocuses the dedicated page as "Securing Endpoints" and removes all public/private endpoint wording.